### PR TITLE
Use newer Container

### DIFF
--- a/check_selenium_docker.py
+++ b/check_selenium_docker.py
@@ -41,11 +41,12 @@ parser.add_argument('--no-newlines', action='store_true',
                     help="print newlines literally on multiline output")
 parser.add_argument("path", type=str, help="path to selenium test")
 args = parser.parse_args()
-path = args.path
+path = os.path.realpath(args.path)
 browser = args.browser
 timeout = abs(args.timeout)
 verbose = args.verbose
 os.chdir(path)
+
 if browser not in ['chrome', 'firefox', 'opera']:
     print("Error: not allowed browser!")
     sys.exit(3)

--- a/dockerimage/Dockerfile
+++ b/dockerimage/Dockerfile
@@ -17,8 +17,7 @@ RUN npm install -g selenium-side-runner
 RUN mkdir /sides && chown -R seluser /sides
 VOLUME [ "/sides" ]
 
-RUN mkdir /selenium-side-runner && chown -R seluser /selenium-side-runner \
-  && mkdir /selenium-side-runner/out && chown -R seluser /selenium-side-runner/out
+RUN mkdir -p /selenium-side-runner/out && chown -R seluser /selenium-side-runner
 WORKDIR /selenium-side-runner
 
 # Five seconds after starting container (as deamon) selenium-side-runner will run every /sides/*.side file

--- a/dockerimage/Dockerfile
+++ b/dockerimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:3.141.59-xenon
+FROM selenium/standalone-chrome:3.141.59
 
 LABEL maintainer="Opsdis Consulting AB <info@opsdis.com>"
 
@@ -17,7 +17,8 @@ RUN npm install -g selenium-side-runner
 RUN mkdir /sides && chown -R seluser /sides
 VOLUME [ "/sides" ]
 
-RUN mkdir /selenium-side-runner && chown -R seluser /selenium-side-runner
+RUN mkdir /selenium-side-runner && chown -R seluser /selenium-side-runner \
+  && mkdir /selenium-side-runner/out && chown -R seluser /selenium-side-runner/out
 WORKDIR /selenium-side-runner
 
 # Five seconds after starting container (as deamon) selenium-side-runner will run every /sides/*.side file


### PR DESCRIPTION
Possible improvement. Feel free to merge or not.

The old base container was two years old. Use a newer one. Now Ubuntu 20.04 is used instead of 18.04.
A switch to newer containers is now possible.